### PR TITLE
Fix duplicate plan steps for fragment spreads in nested fields

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -385,6 +385,20 @@ func (p *MinQueriesPlanner) extractSelection(ctx *PlanningContext, config *extra
 		locationFields[config.parentLocation] = append(locationFields[config.parentLocation], &ast.Field{Name: "id"})
 	}
 
+	// Register the parent location's fragment definitions on the step BEFORE
+	// processing currentLocationFields. Without this, the FragmentSpread case
+	// (line ~470) falls back to config.plan.FragmentDefinitions which contains
+	// the FULL original fragment — including fields that were already split off
+	// to other locations in groupSelectionSet above. That causes duplicate child
+	// steps for those other locations.
+	if parentFrags, ok := locationFragments[config.parentLocation]; ok {
+		for _, frag := range parentFrags {
+			if existing := config.step.FragmentDefinitions.ForName(frag.Name); existing == nil {
+				config.step.FragmentDefinitions = append(config.step.FragmentDefinitions, frag)
+			}
+		}
+	}
+
 	// now we have to generate a selection set for fields that are coming from the same location as the parent
 	currentLocationFields, ok := locationFields[config.parentLocation]
 	if !ok {

--- a/plan_test.go
+++ b/plan_test.go
@@ -1792,3 +1792,80 @@ func TestPlanQuery_scrubWithAlias(t *testing.T) {
 	assert.Equal(t, "allUsers", firstField.Name)
 	assert.Equal(t, "users", firstField.Alias)
 }
+
+// TestPlanQuery_fragmentSpreadNoDuplicateSteps verifies that a fragment spread
+// mixing fields from two services does not produce duplicate plan steps.
+//
+// When a fragment is used inside a nested field (not at the query root),
+// groupSelectionSet splits it by location and creates a child step for the
+// remote service's fields. The main processing loop must then use the
+// location-filtered fragment definition — not the original plan-level fragment
+// which still contains ALL fields. Without this, extractSelection re-discovers
+// the remote fields and creates a second, identical step.
+func TestPlanQuery_fragmentSpreadNoDuplicateSteps(t *testing.T) {
+	t.Parallel()
+
+	// Service A owns Wrapper.item and Item.name.
+	// Service B owns Item.extra.
+	// A fragment on Item mixes fields from both services.
+	// The bug: when the fragment is used inside a nested field (Wrapper.item),
+	// the planner created two identical steps for service B.
+	schemaA, err := graphql.LoadSchema(`
+		interface Node { id: ID! }
+		type Item implements Node { id: ID! name: String }
+		type Wrapper { item: Item }
+		type Query { node(id: ID!): Node  wrappers: [Wrapper!]! }
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	schemaB, err := graphql.LoadSchema(`
+		interface Node { id: ID! }
+		type Item implements Node { id: ID! extra: String }
+		type Query { node(id: ID!): Node }
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gw, err := New([]*graphql.RemoteSchema{
+		{Schema: schemaA, URL: "A"},
+		{Schema: schemaB, URL: "B"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plans, err := gw.planner.Plan(&PlanningContext{
+		Query: `
+			query {
+				wrappers {
+					item { ...frag }
+				}
+			}
+			fragment frag on Item { name extra }
+		`,
+		Schema:    gw.schema,
+		Locations: gw.fieldURLs,
+		Gateway:   gw,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Count every step that targets service B across the entire plan tree.
+	var countB int
+	var walk func(s *QueryPlanStep)
+	walk = func(s *QueryPlanStep) {
+		if q, ok := s.Queryer.(*graphql.SingleRequestQueryer); ok && q.URL() == "B" {
+			countB++
+		}
+		for _, c := range s.Then {
+			walk(c)
+		}
+	}
+	walk(plans[0].RootStep)
+
+	assert.Equal(t, 1, countB, "expected exactly 1 step for service B, got %d", countB)
+}


### PR DESCRIPTION
## The problem

The query planner sends duplicate HTTP requests to backend services when a **named fragment spread** is used inside a **nested field** and the fragment mixes fields from multiple services.

For example, the `articleRichTextQuery` in production uses this pattern:

```graphql
currentUserArticles(eids: $eids) {
  article {                          # ← nested field
    ...articleRichTextFullFragment   # ← fragment mixing two services
  }
}
fragment articleRichTextFullFragment on Article {
  title                   # ← nextapi
  capiRichTextSections    # ← content-api
  capiSources             # ← content-api
}
```

This caused the gateway to send **two identical requests** to content-api for every article — same query, same variables, same response. We confirmed this via Datadog traces: both content-api spans had the same `graphql.query` and the same `id` variable (`QXJ0aWNsZTp5NTBkNWc=`).

## Root cause

`extractSelection` processes a selection set in two phases:

1. **`groupSelectionSet`** splits the fragment's fields by service location, creating a child step for each remote service (e.g. content-api gets `{capiRichTextSections, capiSources}`). It also produces a **location-filtered** fragment definition for the current service (e.g. `frag → {title}` for nextapi).

2. **The main processing loop** encounters the same fragment spread in the current location's fields and calls `extractSelection` recursively. To do so, it looks up the fragment definition in two places:
   ```go
   defn := config.step.FragmentDefinitions.ForName(selection.Name)  // (1) step-local
   if defn == nil {
       defn = config.plan.FragmentDefinitions.ForName(selection.Name)  // (2) original
   }
   ```
The step-local copy was never registered, so the lookup fell through to the **original plan-level fragment** — which still contained ALL fields, including the content-api fields. The recursive call discovered those fields again and created a second, identical child step.

This bug has existed since the original fragment handling was added in [nautilus/gateway#37](https://github.com/nautilus/gateway/pull/37) (Jan 2019). It was never caught because all existing tests used either inline fields or
fragment spreads at the query root level — never a fragment spread inside a nested field where the fragment mixes services.

## The fix

After `groupSelectionSet` returns the location-filtered fragment definitions, register the **current location's filtered fragments** onto the step before the main processing loop runs:

```go
if parentFrags, ok := locationFragments[config.parentLocation]; ok {
    for _, frag := range parentFrags {
        if existing := config.step.FragmentDefinitions.ForName(frag.Name); existing == nil {
            config.step.FragmentDefinitions = append(config.step.FragmentDefinitions, frag)
        }
    }
}
```

Now when the main loop looks up the fragment, it finds the filtered version (containing only the current service's fields) and never falls through to the full original. The recursive call sees no remote fields and creates no
duplicate step.

### Before and after

```
BEFORE:                              AFTER:

  nextapi step                         nextapi step
    ├── content-api step (phase 1)       └── content-api step (phase 1)
    └── content-api step (phase 2)
         ↑ duplicate
```

## Test plan

- [x] New test `TestPlanQuery_fragmentSpreadNoDuplicateSteps` — two services sharing a type, fragment spread inside a nested field mixing fields from both. Fails before the fix (2 steps for service B), passes after (1 step).
- [x] All existing planner, executor, and gateway tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)