### PR TITLE
Update golangci-lint-action from v6 to v7

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
           go-version: 1.26.x  # Avoid latest here. New Go versions can break linters.
       - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.9.0
 


### PR DESCRIPTION
## The problem

The CI lint job fails on every PR and push to master with:

```
invalid version string 'v2.9.0', golangci-lint v2 is not supported by
golangci-lint-action v6, you must update to golangci-lint-action v7.
```

## The fix

Update `golangci/golangci-lint-action` from `v6` to `v7` in `run-tests.yml`. The lint action v7 adds support for golangci-lint v2.x, which we already pin to (`v2.9.0`).

## Test plan

- [ ] CI lint job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)