### PR TITLE
Add CODEOWNERS for @amboss-mededu/software-platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @amboss-mededu/software-platform


### PR DESCRIPTION
This PR adds a `.github/CODEOWNERS` file assigning `@amboss-mededu/software-platform` as the default owner.